### PR TITLE
Fix behavior of Filter#off!/all!

### DIFF
--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -100,11 +100,11 @@ module Console
 		end
 		
 		def off!
-			@level = -1
+			@level = self.class::MAXIMUM_LEVEL + 1
 		end
 		
 		def all!
-			@level = self.class::MAXIMUM_LEVEL
+			@level = -1
 		end
 		
 		# You can enable and disable logging for classes. This function checks if logging for a given subject is enabled.

--- a/spec/console/logger_spec.rb
+++ b/spec/console/logger_spec.rb
@@ -92,4 +92,30 @@ RSpec.describe Console::Logger do
 			subject.debug(object, message)
 		end
 	end
+
+	describe "#off!" do
+		before do
+			subject.off!
+		end
+
+		described_class::LEVELS.each do |name, level|
+			it "doesn't log #{name} messages" do
+				expect(output).to_not receive(:call)
+				subject.send(name, message)
+			end
+		end
+  end
+
+  describe "#all!" do
+  	before do
+			subject.all!
+		end
+
+  	described_class::LEVELS.each do |name, level|
+			it "can log #{name} messages" do
+				expect(output).to receive(:call).with(message, severity: name)
+				subject.send(name, message)
+			end
+		end
+  end
 end


### PR DESCRIPTION
Verbosity typically decreases numerically (e.g. `debug=0`, `fatal=4`), so `Console::Filter#all!` should set `level` to min, while `Console::Filter#off!` should set to one greater than max.