### PR TITLE
Allow setting different logging levels for classes.

### DIFF
--- a/spec/console/console_spec.rb
+++ b/spec/console/console_spec.rb
@@ -85,6 +85,23 @@ RSpec.describe Console do
 			expect(Console.default_log_level({'CONSOLE_LEVEL' => 'debug'})).to be == Console::Logger::DEBUG
 		end
 	end
+	
+	describe '#default_resolver' do
+		let(:logger) { Console.logger }
+		
+		it 'can set custom log levels from ENV' do
+			expect(Console.default_resolver(logger)).to be_nil
+			expect(Console.default_resolver(logger, {'CONSOLE_WARN' => 'Acorn,Banana', 'CONSOLE_DEBUG' => 'Cat'})).to be_a Console::Resolver
+			
+			class Acorn; end
+			class Banana; end
+			class Cat; end
+			
+			expect(Console.logger.subjects[Acorn]).to be == Console::Logger::WARN
+			expect(Console.logger.subjects[Banana]).to be == Console::Logger::WARN
+			expect(Console.logger.subjects[Cat]).to be == Console::Logger::DEBUG
+		end
+	end
 
 	describe '#logger' do
 		let!(:original_logger) {described_class.logger}


### PR DESCRIPTION
Currently you can use `CONSOLE_DEBUG=Foo,Bar` but you can't use `CONSOLE_WARN=Foo,Bar` etc. This adds support for setting different logging levels for each class, which overrides the default log level.