### PR TITLE
Fix <level>? query methods

### DIFF
--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -46,7 +46,7 @@ module Console
 					end
 					
 					define_method("#{name}?") do
-						@level >= level
+						@level <= level
 					end
 				end
 			end

--- a/spec/console/console_spec.rb
+++ b/spec/console/console_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Console do
 			MyModule.log_error
 			
 			expect(io.string).to include("Caused by ArgumentError: It broken!")
+			expect(MyModule.logger.debug?).to be == false
+			expect(MyModule.logger.info?).to be == true
 		end
 	end
 	

--- a/spec/console/logger_spec.rb
+++ b/spec/console/logger_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Console::Logger do
 			it "doesn't log #{name} messages" do
 				expect(output).to_not receive(:call)
 				subject.send(name, message)
+				expect(subject.send("#{name}?")).to be == false
 			end
 		end
   end
@@ -115,6 +116,7 @@ RSpec.describe Console::Logger do
 			it "can log #{name} messages" do
 				expect(output).to receive(:call).with(message, severity: name)
 				subject.send(name, message)
+				expect(subject.send("#{name}?")).to be == true
 			end
 		end
   end


### PR DESCRIPTION
This fixes some inverted logic, where currently:
```ruby
> Console.logger.info!
> Console.logger.debug?
=> true
> Console.logger.warn?
=> false
```

I would expect that when in `info` log level or higher, that `debug?` would return false.

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
