### PR TITLE
require console/version from lib/console.rb

### DIFF
--- a/lib/console.rb
+++ b/lib/console.rb
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require_relative 'console/version'
 require_relative 'console/logger'
 
 module Console


### PR DESCRIPTION
With this change, the console library will have access to its version number, according to the issue https://github.com/socketry/console/issues/13.

## Types of Changes

- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
