### PR TITLE
Generate regex for cleaning the root path in Failure only once

### DIFF
--- a/lib/console/event/failure.rb
+++ b/lib/console/event/failure.rb
@@ -66,12 +66,14 @@ module Console
 					output.puts "  #{terminal[:exception_detail]}#{line}#{terminal.reset}"
 				end
 				
+				root_expr = /^#{@root}\// if @root
+
 				exception.backtrace&.each_with_index do |line, index|
 					path, offset, message = line.split(":")
 					
 					# Make the path a bit more readable
-					path.gsub!(/^#{@root}\//, "./") if @root
-					
+					path.sub!(root_expr, "./") if root_expr
+
 					output.puts "  #{index == 0 ? "→" : " "} #{terminal[:exception_backtrace]}#{path}:#{offset}#{terminal.reset} #{message}"
 				end
 				

--- a/spec/console/event/failure_spec.rb
+++ b/spec/console/event/failure_spec.rb
@@ -1,0 +1,40 @@
+require 'console'
+require 'console/capture'
+
+RSpec.describe Console::Event::Failure do
+	let(:output) {StringIO.new}
+	let(:terminal) {Console::Terminal.for(output)}
+	let(:error) {
+		RuntimeError.new("Test").tap {|e|
+			e.set_backtrace([
+				"(irb):2:in `rescue in irb_binding'",
+				"(irb):1:in `irb_binding'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `eval'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `evaluate'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/context.rb:450:in `evaluate'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:541:in `block (2 levels) in eval_input'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:704:in `signal_status'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:538:in `block in eval_input'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:166:in `block (2 levels) in each_top_level_statement'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `loop'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `block in each_top_level_statement'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `catch'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `each_top_level_statement'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:537:in `eval_input'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:472:in `block in run'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `catch'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `run'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:400:in `start'",
+				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/exe/irb:11:in `<top (required)>'",
+				"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `load'",
+				"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `<main>'"
+			])
+		}
+	}
+	
+	it "formats exception removing root path" do
+		event = Console::Event::Failure.new(error, "/path/to/root")
+		event.format(output, terminal, true)
+		expect(output.string.lines[3..-1]).to all match(/^\s+\.\//)
+	end
+end


### PR DESCRIPTION
## Description

When `Failure` cleans the given root path from a backtrace, the Rexexp used for that will only be generated once, instead of once per line. 
It also uses `sub!` instead of `gsub!` b/c we can safely break after the first match.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
