### PR TITLE
Support for `CONSOLE_OFF=` and `CONSOLE_ALL=`

### DIFF
--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -102,7 +102,7 @@ module Console
 		end
 		
 		def all!
-			@level = -1
+			@level = self.class::MINIMUM_LEVEL - 1
 		end
 		
 		# You can enable and disable logging for classes. This function checks if logging for a given subject is enabled.

--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -26,11 +26,12 @@ module Console
 	class Filter
 		def self.[] **levels
 			klass = Class.new(self)
+			min_level, max_level = levels.values.minmax
 			
 			klass.instance_exec do
 				const_set(:LEVELS, levels)
-				const_set(:MINIMUM_LEVEL, levels.values.min)
-				const_set(:MAXIMUM_LEVEL, levels.values.max)
+				const_set(:MINIMUM_LEVEL, min_level)
+				const_set(:MAXIMUM_LEVEL, max_level)
 				
 				levels.each do |name, level|
 					const_set(name.to_s.upcase, level)

--- a/lib/console/resolver.rb
+++ b/lib/console/resolver.rb
@@ -38,9 +38,24 @@ module Console
 				.to_h
 				.compact
 			
+			off_klasses = env['CONSOLE_OFF']&.split(',')
+			all_klasses = env['CONSOLE_ALL']&.split(',')
+
 			# If we have any levels, then create a class resolver, and each time a class is resolved, set the log level for that class to the specified level:
-			if levels.any?
+			if levels.any? || all_klasses&.any? || off_klasses&.any?
 				resolver = Resolver.new
+
+				if all_klasses
+					resolver.bind(all_klasses) do |klass|
+						logger.enable(klass, logger.class::MINIMUM_LEVEL - 1)
+					end
+				end
+
+				if off_klasses
+					resolver.bind(off_klasses) do |klass|
+						logger.disable(klass)
+					end
+				end
 				
 				levels.each do |level, names|
 					resolver.bind(names) do |klass|

--- a/lib/console/resolver.rb
+++ b/lib/console/resolver.rb
@@ -33,7 +33,7 @@ module Console
 		# @returns [Resolver] If there were custom logging levels, then the created resolver is returned.
 		def self.default_resolver(logger, env = ENV)
 			# Find all CONSOLE_<LEVEL> variables from environment:
-			levels = Logger::LEVELS
+			levels = logger.class::LEVELS
 				.map{|label, level| [level, env["CONSOLE_#{label.upcase}"]&.split(',')]}
 				.to_h
 				.compact

--- a/spec/console/resolver_spec.rb
+++ b/spec/console/resolver_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe Console::Resolver do
 			expect(Console.logger.subjects[Banana]).to be == Console::Logger::WARN
 			expect(Console.logger.subjects[Cat]).to be == Console::Logger::DEBUG
 		end
+
+		it 'can set "all" and "off" by environment' do
+			expect(Console::Resolver.default_resolver(logger, {'CONSOLE_ALL' => 'Cat', 'CONSOLE_WARN' => 'Dog', 'CONSOLE_OFF' => 'Acorn,Banana'})).to be_a Console::Resolver
+
+			class Acorn; end
+			class Banana; end
+			class Cat; end
+			class Dog; end
+
+			expect(Console.logger.subjects[Acorn]).to be_nil
+			expect(Console.logger.subjects[Banana]).to be_nil
+			expect(Console.logger.subjects[Cat]).to be == Console::Logger::MINIMUM_LEVEL - 1
+			expect(Console.logger.subjects[Dog]).to be == Console::Logger::WARN
+		end
 	end
 end


### PR DESCRIPTION
## Description

See #21 

```console
$ CONSOLE_LEVEL=error CONSOLE_ALL=Focus::Class CONSOLE_OFF=Not::Interested::Class ./machine
```

### Types of Changes

- New feature.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
