### PR TITLE
Draft: Allow output and format to be changed via ENV

### DIFF
--- a/lib/console/logger.rb
+++ b/lib/console/logger.rb
@@ -56,7 +56,7 @@ module Console
 			end
 		end
 
-		def self.default_terminal(output = nil, env = ENV, verbose: self.verbose?)
+		def self.default_terminal(output = nil, env: ENV, verbose: self.verbose?)
 			logger = nil
 			format = env['CONSOLE_FORMAT']
 			output ||= default_output(env)

--- a/lib/console/logger.rb
+++ b/lib/console/logger.rb
@@ -23,6 +23,7 @@ require_relative 'progress'
 
 require_relative 'resolver'
 require_relative 'terminal/logger'
+require_relative 'serialized/logger'
 
 require 'fiber/local'
 
@@ -44,14 +45,47 @@ module Console
 				INFO
 			end
 		end
+
+		def self.default_output(env = ENV)
+			output = env['CONSOLE_OUTPUT']
+			case output&.upcase
+			when '-', 'STDOUT'
+				$stdout
+			when 'STDERR', nil
+				$stderr
+			end
+		end
+
+		def self.default_terminal(output = nil, env = ENV, verbose: self.verbose?)
+			logger = nil
+			format = env['CONSOLE_FORMAT']
+			output ||= default_output(env)
+
+			case format&.upcase
+			when nil
+				logger = Terminal::Logger.new(output, verbose: verbose)
+			when 'XTERM'
+				logger = Terminal::Logger.new(output, verbose: verbose, format: Terminal::XTerm)
+			when 'TEXT', 'TERM'
+				logger = Terminal::Logger.new(output, verbose: verbose, format: Terminal::Text)
+			else
+				Resolver.new.bind([format]) do |klass|
+					logger = Serialized::Logger.new(output, format: klass)
+				end
+			end
+
+			raise "No format found for #{format}" unless logger
+
+			logger
+		end
 		
 		# Controls verbose output using `$VERBOSE`.
 		def self.verbose?(env = ENV)
 			!$VERBOSE.nil? || env['CONSOLE_VERBOSE']
 		end
 		
-		def self.default_logger(output, verbose: self.verbose?, level: self.default_log_level)
-			terminal = Terminal::Logger.new(output, verbose: verbose)
+		def self.default_logger(output = self.default_output, terminal: nil, verbose: self.verbose?, level: self.default_log_level)
+			terminal ||= self.default_terminal(output, verbose: verbose)
 			
 			logger = self.new(terminal, verbose: verbose, level: level)
 			Resolver.default_resolver(logger)

--- a/lib/console/terminal/logger.rb
+++ b/lib/console/terminal/logger.rb
@@ -54,11 +54,11 @@ module Console
 		end
 		
 		class Logger
-			def initialize(io = $stderr, verbose: nil, start_at: Terminal.start_at!, **options)
+			def initialize(io = $stderr, verbose: nil, start_at: Terminal.start_at!, format: nil, **options)
 				@io = io
 				@start_at = start_at
 				
-				@terminal = Terminal.for(io)
+				@terminal = format.nil? ? Terminal.for(io) : format.new(io)
 				
 				if verbose.nil?
 					@verbose = !@terminal.colors?

--- a/spec/console/logger_spec.rb
+++ b/spec/console/logger_spec.rb
@@ -202,25 +202,26 @@ RSpec.describe Console::Logger do
 
 		it 'can force format to XTERM for non tty output by ENV' do
 			io = StringIO.new
+			expect(Console::Terminal).not_to receive(:for).with(io)
 			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'XTERM'})
 			expect(terminal).to be_a Console::Terminal::Logger
 			expect(terminal.terminal).to be_a Console::Terminal::XTerm
 		end
 
 		it 'can force format to TEXT for tty output by ENV using TERM' do
-			File.open("/dev/tty") { |io|
-				terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TERM'})
-				expect(terminal).to be_a Console::Terminal::Logger
-				expect(terminal.terminal).to be_a Console::Terminal::Text
-			}
+			io = StringIO.new
+			expect(Console::Terminal).not_to receive(:for).with(io)
+			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TERM'})
+			expect(terminal).to be_a Console::Terminal::Logger
+			expect(terminal.terminal).to be_a Console::Terminal::Text
 		end
 
 		it 'can force format to TEXT for tty output by ENV using TEXT' do
-			File.open("/dev/tty") { |io|
-				terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TEXT'})
-				expect(terminal).to be_a Console::Terminal::Logger
-				expect(terminal.terminal).to be_a Console::Terminal::Text
-			}
+			io = StringIO.new
+			expect(Console::Terminal).not_to receive(:for).with(io)
+			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TEXT'})
+			expect(terminal).to be_a Console::Terminal::Logger
+			expect(terminal.terminal).to be_a Console::Terminal::Text
 		end
 	end
 end

--- a/spec/console/logger_spec.rb
+++ b/spec/console/logger_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Console::Logger do
 		end
 
 		it 'can set terminal to Serialized and format to JSON by ENV' do
-			terminal = Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'JSON'})
+			terminal = Console::Logger.default_terminal(nil, env: {'CONSOLE_FORMAT' => 'JSON'})
 			expect(terminal).to be_a Console::Serialized::Logger
 			expect(terminal.format).to be == JSON
 		end
@@ -189,21 +189,21 @@ RSpec.describe Console::Logger do
 		it 'can set terminal to Serialized using custom format by ENV' do
 			class MySerializer
 			end
-			terminal = Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'MySerializer'})
+			terminal = Console::Logger.default_terminal(nil, env: {'CONSOLE_FORMAT' => 'MySerializer'})
 			expect(terminal).to be_a Console::Serialized::Logger
 			expect(terminal.format).to be == MySerializer
 		end
 
 		it 'raises error until the given format class is available' do
 			expect {
-				Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'NotThereYet'})
+				Console::Logger.default_terminal(nil, env: {'CONSOLE_FORMAT' => 'NotThereYet'})
 			}.to raise_error(RuntimeError, 'No format found for NotThereYet')
 		end
 
 		it 'can force format to XTERM for non tty output by ENV' do
 			io = StringIO.new
 			expect(Console::Terminal).not_to receive(:for).with(io)
-			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'XTERM'})
+			terminal = Console::Logger.default_terminal(io, env: {'CONSOLE_FORMAT' => 'XTERM'})
 			expect(terminal).to be_a Console::Terminal::Logger
 			expect(terminal.terminal).to be_a Console::Terminal::XTerm
 		end
@@ -211,7 +211,7 @@ RSpec.describe Console::Logger do
 		it 'can force format to TEXT for tty output by ENV using TERM' do
 			io = StringIO.new
 			expect(Console::Terminal).not_to receive(:for).with(io)
-			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TERM'})
+			terminal = Console::Logger.default_terminal(io, env: {'CONSOLE_FORMAT' => 'TERM'})
 			expect(terminal).to be_a Console::Terminal::Logger
 			expect(terminal.terminal).to be_a Console::Terminal::Text
 		end
@@ -219,7 +219,7 @@ RSpec.describe Console::Logger do
 		it 'can force format to TEXT for tty output by ENV using TEXT' do
 			io = StringIO.new
 			expect(Console::Terminal).not_to receive(:for).with(io)
-			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TEXT'})
+			terminal = Console::Logger.default_terminal(io, env: {'CONSOLE_FORMAT' => 'TEXT'})
 			expect(terminal).to be_a Console::Terminal::Logger
 			expect(terminal.terminal).to be_a Console::Terminal::Text
 		end

--- a/spec/console/logger_spec.rb
+++ b/spec/console/logger_spec.rb
@@ -152,4 +152,75 @@ RSpec.describe Console::Logger do
 			expect(Console::Logger.default_log_level({'CONSOLE_LEVEL' => 'debug'})).to be == Console::Logger::DEBUG
 		end
 	end
+
+	describe '.default_output' do
+		it 'should set the default output to $stderr' do
+			expect(Console::Logger.default_output).to be == $stderr
+		end
+
+		it 'can set output to $stdout by ENV via "STDERR"' do
+			expect(Console::Logger.default_output({'CONSOLE_OUTPUT' => 'STDERR'})).to be == $stderr
+		end
+
+		it 'can set output to $stdout by ENV via "STDOUT"' do
+			expect(Console::Logger.default_output({'CONSOLE_OUTPUT' => 'STDOUT'})).to be == $stdout
+		end
+
+		it 'can set output to $stdout by ENV via "-"' do
+			expect(Console::Logger.default_output({'CONSOLE_OUTPUT' => '-'})).to be == $stdout
+		end
+	end
+
+	describe '.default_terminal' do
+		it 'should set the default to Terminal::Logger' do
+			expect(Console::Logger.default_terminal).to be_a Console::Terminal::Logger
+		end
+
+		it 'should set the loggers io to the default_output' do
+			expect(Console::Logger.default_terminal.io).to be == Console::Logger.default_output
+		end
+
+		it 'can set terminal to Serialized and format to JSON by ENV' do
+			terminal = Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'JSON'})
+			expect(terminal).to be_a Console::Serialized::Logger
+			expect(terminal.format).to be == JSON
+		end
+
+		it 'can set terminal to Serialized using custom format by ENV' do
+			class MySerializer
+			end
+			terminal = Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'MySerializer'})
+			expect(terminal).to be_a Console::Serialized::Logger
+			expect(terminal.format).to be == MySerializer
+		end
+
+		it 'raises error until the given format class is available' do
+			expect {
+				Console::Logger.default_terminal(nil, {'CONSOLE_FORMAT' => 'NotThereYet'})
+			}.to raise_error(RuntimeError, 'No format found for NotThereYet')
+		end
+
+		it 'can force format to XTERM for non tty output by ENV' do
+			io = StringIO.new
+			terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'XTERM'})
+			expect(terminal).to be_a Console::Terminal::Logger
+			expect(terminal.terminal).to be_a Console::Terminal::XTerm
+		end
+
+		it 'can force format to TEXT for tty output by ENV using TERM' do
+			File.open("/dev/tty") { |io|
+				terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TERM'})
+				expect(terminal).to be_a Console::Terminal::Logger
+				expect(terminal.terminal).to be_a Console::Terminal::Text
+			}
+		end
+
+		it 'can force format to TEXT for tty output by ENV using TEXT' do
+			File.open("/dev/tty") { |io|
+				terminal = Console::Logger.default_terminal(io, {'CONSOLE_FORMAT' => 'TEXT'})
+				expect(terminal).to be_a Console::Terminal::Logger
+				expect(terminal.terminal).to be_a Console::Terminal::Text
+			}
+		end
+	end
 end


### PR DESCRIPTION
## Description

The default output might be changed to STDOUT using ENV var `CONSOLE_OUTPUT`.
Using `CONSOLE_FORMAT`, the format might be forced to Term (aka Text), XTerm.
The format can also be forced to Serialized by providing a serializer class name (like “JSON”)

Ref #20

No support for logging into files (yet?) - I figured, it's bit more complicated to deal with opening, closing, reopening files etc.

### Types of Changes

- New feature.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
