### PR TITLE
Avoid "shadowing outer local variable - output"

### DIFF
--- a/lib/console/output.rb
+++ b/lib/console/output.rb
@@ -29,8 +29,8 @@ module Console
 			if names = env['CONSOLE_OUTPUT']
 				names = names.split(',').map(&:to_sym).reverse
 				
-				names.inject(output) do |output, name|
-					Output.const_get(name).new(output, **options)
+				names.inject(output) do |output_argument, name|
+					Output.const_get(name).new(output_argument, **options)
 				end
 			else
 				return Output::Default.new(output, **options)


### PR DESCRIPTION
## Description

saw "gems/console-1.12.0/lib/console/output.rb:32: warning: shadowing outer local variable - output" as I was inspecting some test output.

This chore PR avoids that being output by naming the local.

### Types of Changes

- Maintenance.

### Testing

...