### PR TITLE
Rename severity -> level.

### DIFF
--- a/guides/getting-started/README.md
+++ b/guides/getting-started/README.md
@@ -14,7 +14,7 @@ $ bundle add console
 
 `console` has several core concepts:
 
-- A log message which consists of a set of arguments and options, which includes a timestamp, severity, and other structured data.
+- A log message which consists of a set of arguments and options, which includes a timestamp, level, and other structured data.
 - A {ruby Console::Logger} instance which is the main entry point for logging for a specific system and writes data to a given output formatter.
 - An output instance such as {ruby Console::XTerm}, {ruby Console::Serialized::Logger} which formats these log messages and writes them to a specific output device.
 - An event instance, such as {ruby Console::Event::Progress} or {ruby Console::Event::Spawn} which represents a structured event within a system, which can be formatted in a specific way.
@@ -33,13 +33,14 @@ Console.logger.info("Hello World")
 <font color="#00AA00">  0.0s     info:</font> <b>Hello World</b> <font color="#717171">[pid=219113] [2020-08-08 12:21:26 +1200]</font>
 </pre>
 
-The method name `info` indicates the severity level of the log message. You can filter out severity levels, and by default, `debug` messages are filtered out. Here are some examples of the different log levels:
+The method name `info` indicates the level of the log message. You can filter out levels, and by default, `debug` messages are filtered out. Here are some examples of the different log levels:
 
 ~~~ ruby
 require 'console'
 
 Console.logger.debug("The input voltage has stabilized.")
 Console.logger.info("Making a request to the machine.")
+Console.logger.audit("The user has logged in!")
 Console.logger.warn("The machine has detected a temperature anomaly.")
 Console.logger.error("The machine was unable to complete the request!")
 Console.logger.fatal("Depressurisation detected, evacuate the area!")
@@ -91,7 +92,7 @@ If you want to disable log messages which come from this particular class, you c
 $ CONSOLE_FATAL=Machine ./machine
 ~~~
 
-This will prevent any log message which has a subject of class `Machine` from logging messages of a severity less than `fatal`.
+This will prevent any log message which has a subject of class `Machine` from logging messages of a level less than `fatal`.
 
 ## Exception Logging
 

--- a/guides/getting-started/old.md
+++ b/guides/getting-started/old.md
@@ -131,7 +131,7 @@ require 'console'
 
 MyLogger = Console::Filter[noise: 0, stuff: 1, broken: 2]
 
-# verbose: true - log severity/name/pid etc.
+# verbose: true - log level/name/pid etc.
 logger = MyLogger.new(Console.logger, name: "Java", verbose: true)
 
 logger.broken("It's so janky.")
@@ -169,7 +169,7 @@ end
 logger = Console::Logger.new(output)
 
 logger.info("Hello World!", meta: "data") {"block"}
-# => arguments: ["Hello World!"] options: {:severity=>:info, :meta=>"data"} block: block
+# => arguments: ["Hello World!"] options: {:level=>:info, :meta=>"data"} block: block
 ```
 
 ## Contributing

--- a/lib/console/capture.rb
+++ b/lib/console/capture.rb
@@ -40,10 +40,10 @@ module Console
 			@verbose
 		end
 		
-		def call(subject = nil, *arguments, severity: UNKNOWN, **options, &block)
+		def call(subject = nil, *arguments, level: UNKNOWN, **options, &block)
 			message = {
 				time: ::Time.now.iso8601,
-				severity: severity,
+				level: level,
 				**options,
 			}
 			

--- a/lib/console/compatible/logger.rb
+++ b/lib/console/compatible/logger.rb
@@ -36,10 +36,10 @@ module Console
 				@logdev = LogDevice.new(subject, output)
 			end
 			
-			def add(severity, message = nil, progname = nil)
-				severity ||= UNKNOWN
+			def add(level, message = nil, progname = nil)
+				level ||= UNKNOWN
 				
-				if @logdev.nil? or severity < level
+				if @logdev.nil? or level < level
 					return true
 				end
 				
@@ -58,14 +58,14 @@ module Console
 				
 				@logdev.call(
 					progname, message,
-					severity: format_severity(severity)
+					level: format_level(level)
 				)
 				
 				return true
 			end
 			
-			def format_severity(value)
-				super.downcase.to_sym
+			def format_level(value)
+				format_severity(value).downcase.to_sym
 			end
 		end
 	end

--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -26,7 +26,7 @@ module Console
 					
 					define_method(name) do |subject = nil, *arguments, **options, &block|
 						if self.enabled?(subject, level)
-							self.call(subject, *arguments, severity: name, **options, **@options, &block)
+							self.call(subject, *arguments, level: name, **options, **@options, &block)
 						end
 					end
 					

--- a/lib/console/serialized/logger.rb
+++ b/lib/console/serialized/logger.rb
@@ -31,10 +31,10 @@ module Console
 				@format.dump(record)
 			end
 			
-			def call(subject = nil, *arguments, severity: UNKNOWN, **options, &block)
+			def call(subject = nil, *arguments, level: UNKNOWN, **options, &block)
 				record = {
 					time: Time.now.iso8601,
-					severity: severity,
+					level: level,
 					class: subject.class,
 					oid: subject.object_id,
 					pid: Process.pid,

--- a/lib/console/terminal/logger.rb
+++ b/lib/console/terminal/logger.rb
@@ -84,14 +84,14 @@ module Console
 			
 			UNKNOWN = :unknown
 			
-			def call(subject = nil, *arguments, name: nil, severity: UNKNOWN, **options, &block)
-				prefix = build_prefix(name || severity.to_s)
+			def call(subject = nil, *arguments, name: nil, level: UNKNOWN, **options, &block)
+				prefix = build_prefix(name || level.to_s)
 				indent = " " * prefix.size
 				
 				buffer = Buffer.new("#{indent}| ")
 				
 				if subject
-					format_subject(severity, prefix, subject, buffer)
+					format_subject(level, prefix, subject, buffer)
 				end
 				
 				if options&.any?
@@ -130,13 +130,13 @@ module Console
 				end
 			end
 			
-			def format_subject(severity, prefix, subject, buffer)
+			def format_subject(level, prefix, subject, buffer)
 				if subject.is_a?(String)
-					format_string_subject(severity, prefix, subject, buffer)
+					format_string_subject(level, prefix, subject, buffer)
 				elsif subject.is_a?(Module)
-					format_string_subject(severity, prefix, subject.to_s, buffer)
+					format_string_subject(level, prefix, subject.to_s, buffer)
 				else
-					format_object_subject(severity, prefix, subject, buffer)
+					format_object_subject(level, prefix, subject, buffer)
 				end
 			end
 			
@@ -150,8 +150,8 @@ module Console
 				buffer << "[ec=0x#{Fiber.current.object_id.to_s(16)}] [pid=#{Process.pid}] [#{::Time.now}]#{@terminal.reset}"
 			end
 			
-			def format_object_subject(severity, prefix, subject, output)
-				prefix_style = @terminal[severity]
+			def format_object_subject(level, prefix, subject, output)
+				prefix_style = @terminal[level]
 				
 				if @verbose
 					suffix = default_suffix(subject)
@@ -162,8 +162,8 @@ module Console
 				output.puts "#{@terminal[:subject]}#{subject.class}#{@terminal.reset}#{suffix}", prefix: prefix
 			end
 			
-			def format_string_subject(severity, prefix, subject, output)
-				prefix_style = @terminal[severity]
+			def format_string_subject(level, prefix, subject, output)
+				prefix_style = @terminal[level]
 				
 				if @verbose
 					suffix = default_suffix

--- a/test/console/capture.rb
+++ b/test/console/capture.rb
@@ -24,7 +24,7 @@ describe Console::Capture do
 			
 			last = capture.last
 			expect(last).to have_keys(
-				severity: be == :info,
+				level: be == :info,
 				subject: be == "Hello World!"
 			)
 		end
@@ -36,7 +36,7 @@ describe Console::Capture do
 			
 			last = capture.last
 			expect(last).to have_keys(
-				severity: be == :info,
+				level: be == :info,
 				message: be == "Hello World!"
 			)
 		end
@@ -48,7 +48,7 @@ describe Console::Capture do
 			
 			last = capture.last
 			expect(last).to have_keys(
-				severity: be == :info,
+				level: be == :info,
 				message: be == "Hello World!"
 			)
 		end

--- a/test/console/compatible/logger.rb
+++ b/test/console/compatible/logger.rb
@@ -16,8 +16,8 @@ describe Console::Compatible::Logger do
 		expect(io.string).to be(:include?, "Hello World")
 	end
 	
-	it "formats lower case severity string" do
-		expect(logger.format_severity(1)).to be == :info
+	it "formats lower case level string" do
+		expect(logger.format_level(1)).to be == :info
 	end
 	
 	it "can write a message" do

--- a/test/console/logger.rb
+++ b/test/console/logger.rb
@@ -42,7 +42,7 @@ describe Console::Logger do
 			
 			last = output.last
 			expect(last).to have_keys(
-				severity: be == :fatal,
+				level: be == :fatal,
 			)
 			expect(last[:arguments].first).to be_a(StandardError)
 		end
@@ -59,7 +59,7 @@ describe Console::Logger do
 	
 	with "default log level" do
 		it "logs info" do
-			expect(output).to receive(:call).with(message, severity: :info)
+			expect(output).to receive(:call).with(message, level: :info)
 			
 			logger.info(message)
 		end
@@ -72,7 +72,7 @@ describe Console::Logger do
 	
 	Console::Logger::LEVELS.each do |name, level|
 		it "can log #{name} messages" do
-			expect(output).to receive(:call).with(message, severity: name)
+			expect(output).to receive(:call).with(message, level: name)
 			
 			logger.level = level
 			logger.send(name, message)
@@ -88,7 +88,7 @@ describe Console::Logger do
 			logger.enable(Object)
 			expect(logger).to be(:enabled?, object)
 			
-			expect(output).to receive(:call).with(object, message, severity: :debug)
+			expect(output).to receive(:call).with(object, message, level: :debug)
 			logger.debug(object, message)
 		end
 	end
@@ -108,7 +108,7 @@ describe Console::Logger do
 			it "can log #{name} messages" do
 				logger.all!
 				
-				expect(output).to receive(:call).with(message, severity: name)
+				expect(output).to receive(:call).with(message, level: name)
 				logger.send(name, message)
 				expect(logger.send("#{name}?")).to be == true
 			end

--- a/test/console/progress.rb
+++ b/test/console/progress.rb
@@ -18,7 +18,7 @@ describe Console::Progress do
 			
 			last = capture.last
 			expect(last).to have_keys(
-				severity: be == :info,
+				level: be == :info,
 				subject: be == "My Measurement",
 				arguments: be == ["Hello World!"],
 			)
@@ -62,7 +62,7 @@ describe Console::Progress do
 			
 			last = capture.last
 			expect(last).to have_keys(
-				severity: be == :info,
+				level: be == :info,
 				subject: be == "My Measurement",
 				message: be_a(Console::Event::Progress),
 			)


### PR DESCRIPTION
I feel like `severity` does not correctly represent what is called level everywhere else. Sometimes it's referred to as "severity level" but that's usually in reference to an integer.

Datadog APM also works with `level` field by default.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Breaking change.

## Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.

## [Developer's Certificate of Origin 1.1](https://developercertificate.org/)

<!--
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.
-->

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
