### PR TITLE
Reduce serialized subject

### DIFF
--- a/lib/console/serialized/logger.rb
+++ b/lib/console/serialized/logger.rb
@@ -42,7 +42,12 @@ module Console
 					pid: Process.pid,
 				}
 				
-				if subject
+				# We want to log just a brief subject:
+				if subject.is_a?(String)
+					record[:subject] = subject
+				elsif subject.is_a?(Module)
+					record[:subject] = subject.name
+				else
 					record[:subject] = subject.class.name
 				end
 				

--- a/lib/console/serialized/logger.rb
+++ b/lib/console/serialized/logger.rb
@@ -43,7 +43,7 @@ module Console
 				}
 				
 				if subject
-					record[:subject] = subject
+					record[:subject] = subject.class.name
 				end
 				
 				if annotation = Fiber.current.annotation

--- a/test/console/serialized/logger.rb
+++ b/test/console/serialized/logger.rb
@@ -36,10 +36,11 @@ describe Console::Serialized::Logger do
 		let(:event) {Console::Event::Spawn.for("ls -lah")}
 		
 		it "can log structured events" do
-			logger.call(event)
+			logger.call(subject, event)
 			
 			expect(record).to have_keys(
-				subject: be == ["Console::Event::Spawn", {:arguments => ["ls -lah"]}]
+				subject: be == subject.name,
+				message: be == ["Console::Event::Spawn", {:arguments => ["ls -lah"]}]
 			)
 		end
 	end


### PR DESCRIPTION
Align the serialized logger subject with the terminal logger subject format. This also reduces the size of the serialized logs.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.
- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
