### PR TITLE
`class` is already part of `subject`.

### DIFF
--- a/lib/console/serialized/logger.rb
+++ b/lib/console/serialized/logger.rb
@@ -37,7 +37,6 @@ module Console
 				record = {
 					time: Time.now.iso8601,
 					severity: severity,
-					class: subject.class,
 					oid: subject.object_id,
 					pid: Process.pid,
 				}


### PR DESCRIPTION
With `subject` updated to be the name of the class, even for the serialized logger, remove `class` as it's redundant.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
