### PR TITLE
Encode serialized output to avoid encoding errors.

### DIFF
--- a/lib/console/output/encoder.rb
+++ b/lib/console/output/encoder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+module Console
+	module Output
+		class Encoder
+			def initialize(output, encoding = ::Encoding::UTF_8)
+				@output = output
+				@encoding = encoding
+			end
+			
+			attr :output
+			
+			attr :encoding
+			
+			def call(subject = nil, *arguments, **options, &block)
+				subject = encode(subject)
+				arguments = encode(arguments)
+				options = encode(options)
+				
+				@output.call(subject, *arguments, **options, &block)
+			end
+			
+			def encode(value)
+				case value
+				when String
+					value.encode(@encoding, invalid: :replace, undef: :replace)
+				when Array
+					value.map{|item| encode(item)}
+				when Hash
+					value.transform_values{|item| encode(item)}
+				else
+					value
+				end
+			end
+		end
+	end
+end

--- a/lib/console/output/json.rb
+++ b/lib/console/output/json.rb
@@ -4,12 +4,16 @@
 # Copyright, 2021-2022, by Samuel Williams.
 
 require_relative '../serialized/logger'
+require_relative 'encoder'
 
 module Console
 	module Output
 		module JSON
 			def self.new(output, **options)
-				Serialized::Logger.new(output, format: ::JSON, **options)
+				# The output encoder can prevent encoding issues (e.g. invalid UTF-8):
+				Output::Encoder.new(
+					Serialized::Logger.new(output, format: ::JSON, **options)
+				)
 			end
 		end
 	end

--- a/test/console/output.rb
+++ b/test/console/output.rb
@@ -71,6 +71,7 @@ describe Console::Output do
 		let(:capture) {StringIO.new}
 		
 		it "should replace invalid characters" do
+			expect(capture).to receive(:tty?).and_return(false)
 			output = Console::Output.new(capture, {})
 			
 			output.call("Hello \xFF")

--- a/test/console/output.rb
+++ b/test/console/output.rb
@@ -76,7 +76,7 @@ describe Console::Output do
 			output.call("Hello \xFF")
 			
 			message = JSON.parse(capture.string)
-			expect(message['subject']).to be == "Hello \uFFFD"
+			expect(message['subject'].inspect).to be == "Hello \uFFFD".inspect
 		end
 	end
 end

--- a/test/console/output.rb
+++ b/test/console/output.rb
@@ -77,7 +77,7 @@ describe Console::Output do
 			output.call("Hello \xFF")
 			
 			message = JSON.parse(capture.string)
-			expect(message['subject'].inspect).to be == "Hello \uFFFD".inspect
+			expect(message['subject']).to be == "Hello \uFFFD"
 		end
 	end
 end

--- a/test/console/output/encoder.rb
+++ b/test/console/output/encoder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require 'console/output/encoder'
+require 'console/capture'
+
+describe Console::Output::Encoder do
+	let(:output) {Console::Capture.new}
+	let(:encoder) {subject.new(output)}
+	
+	let(:invalid_string) {"hello \xc3\x28 world"}
+	it "is an invalid string" do
+		expect(invalid_string).not.to be(:valid_encoding?)
+	end
+	
+	it "can fix encoding" do
+		valid_string = encoder.encode(invalid_string)
+		expect(valid_string).to be(:valid_encoding?)
+	end
+	
+	it "can encode hashes" do
+		invalid = {key: invalid_string}
+		valid = encoder.encode(invalid)
+		
+		expect(valid[:key]).to be(:valid_encoding?)
+	end
+	
+	it "can encode arrays" do
+		invalid = [invalid_string]
+		valid = encoder.encode(invalid)
+		
+		expect(valid.first).to be(:valid_encoding?)
+	end
+	
+	it "ignores non-strings" do
+		expect(encoder.encode(1)).to be == 1
+	end
+end


### PR DESCRIPTION
Introduce `Console::Output::Encoder` which can wrap serialized output to avoid encoding errors.

```
JSON::GeneratorError: source sequence is illegal/malformed utf-8
/usr/local/lib/ruby/3.2.0/json/common.rb:312:in `generate': source sequence is illegal/malformed utf-8 (JSON::GeneratorError)
	from /usr/local/lib/ruby/3.2.0/json/common.rb:312:in `generate'
	from /usr/local/lib/ruby/3.2.0/json/common.rb:641:in `dump'
	from /srv/vendor/bundle/ruby/3.2.0/gems/console-1.18.0/lib/console/serialized/logger.rb:33:in `dump'
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
