### PR TITLE
Expose direct interface on `Console`.

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -15,6 +15,7 @@ $ bundle add console
 `console` has several core concepts:
 
 - A log message which consists of a set of arguments and options, which includes a timestamp, severity, and other structured data.
+- The {ruby Console} module which provides an abstract interface for logging.
 - A {ruby Console::Logger} instance which is the main entry point for logging for a specific system and writes data to a given output formatter.
 - An output instance such as {ruby Console::XTerm}, {ruby Console::Serialized::Logger} which formats these log messages and writes them to a specific output device.
 - An event instance, such as {ruby Console::Event::Progress} or {ruby Console::Event::Spawn} which represents a structured event within a system, which can be formatted in a specific way.
@@ -26,7 +27,7 @@ Out of the box, {ruby Console.logger} is a globally shared logger that outputs t
 ~~~ ruby
 require 'console'
 
-Console.logger.info("Hello World")
+Console.info("Hello World")
 ~~~
 
 <pre>
@@ -38,11 +39,11 @@ The method name `info` indicates the severity level of the log message. You can 
 ~~~ ruby
 require 'console'
 
-Console.logger.debug("The input voltage has stabilized.")
-Console.logger.info("Making a request to the machine.")
-Console.logger.warn("The machine has detected a temperature anomaly.")
-Console.logger.error("The machine was unable to complete the request!")
-Console.logger.fatal("Depressurisation detected, evacuate the area!")
+Console.debug("The input voltage has stabilized.")
+Console.info("Making a request to the machine.")
+Console.warn("The machine has detected a temperature anomaly.")
+Console.error("The machine was unable to complete the request!")
+Console.fatal("Depressurisation detected, evacuate the area!")
 ~~~
 
 From the terminal, you can control the log level using the `CONSOLE_LEVEL` environment variable. To log all messages including `debug`:
@@ -65,7 +66,7 @@ You can add any options you like to a log message and they will be included as p
 
 ~~~ ruby
 duration = measure{...}
-Console.logger.info("Execution completed!", duration: duration)
+Console.info("Execution completed!", duration: duration)
 ~~~
 
 ## Subject Logging
@@ -76,11 +77,9 @@ The first argument to the log statement becomes the implicit subject of the log 
 require 'console'
 
 class Machine
-	include Console
-	
 	def initialize(voltage)
 		@voltage = voltage.floor
-		logger.info(self, "The input voltage has stabilized.")
+		Console.info(self, "The input voltage has stabilized.")
 	end
 end
 
@@ -110,8 +109,6 @@ If your code has an unhandled exception, you may wish to log it. In order to log
 require 'console'
 
 class Cache
-	include Console
-	
 	def initialize
 		@entries = {}
 	end
@@ -119,7 +116,7 @@ class Cache
 	def fetch(key)
 		@entries.fetch(key)
 	rescue => error
-		logger.failure(self, error)
+		Console.error(self, error)
 	end
 end
 
@@ -137,7 +134,7 @@ This will produce the following output:
 
 ## Program Structure
 
-Generally, programs should use the global `Console.logger` instance.
+Generally, programs should use the global `Console` interface to log messages.
 
 Individual classes should not be catching and logging exceptions. It makes for simpler code if this is handled in a few places near the top of your program. Exceptions should collect enough information such that logging them produces a detailed backtrace leading to the failure.
 
@@ -172,7 +169,7 @@ class MyEvent < Console::Event::Generic
 	end
 end
 
-Console.logger.info("It finally happened.", MyEvent.new)
+Console.info("It finally happened.", MyEvent.new)
 ```
 
 #### Failure Events

--- a/guides/integration/readme.md
+++ b/guides/integration/readme.md
@@ -31,24 +31,6 @@ class HappyLogger
 end
 ~~~
 
-## Rails Integration
+## Adapters
 
-Rails is a little bit tricky since it expects a `Logger` instance, and reaches into the internal implementation, so we need to monkeypatch it:
-
-~~~ ruby
-require 'rails'
-
-require 'console'
-require 'console/compatible/logger'
-
-if ActiveSupport::Logger.respond_to?(:logger_outputs_to?)
-  # https://github.com/rails/rails/issues/44800
-  class ActiveSupport::Logger
-    def self.logger_outputs_to?(*)
-      true
-    end
-  end
-end
-
-Rails.logger = Console::Compatible::Logger.new("Rails", Console.logger.output)
-~~~
+- [Console::Adapter::Rails](https://github.com/socketry/console-adapter-rails)

--- a/lib/console.rb
+++ b/lib/console.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2022, by Samuel Williams.
+# Copyright, 2019-2023, by Samuel Williams.
 # Copyright, 2019, by Bryan Powell.
 # Copyright, 2020, by Michael Adams.
 # Copyright, 2021, by Cédric Boutillier.
@@ -10,23 +10,31 @@ require_relative 'console/version'
 require_relative 'console/logger'
 
 module Console
-	def self.logger
-		Logger.instance
-	end
-	
-	def self.logger= instance
-		Logger.instance= instance
+	class << self
+		def logger
+			Logger.instance
+		end
+		
+		def logger= instance
+			Logger.instance= instance
+		end
+		
+		Logger::LEVELS.each do |name, level|
+			define_method(name) do |*arguments, **options, &block|
+				Logger.instance.send(name, *arguments, **options, &block)
+			end
+		end
+		
+		def call(...)
+			Logger.instance.call(...)
+		end
 	end
 	
 	def logger= logger
-		@logger = logger
+		warn "Setting logger on #{self} is deprecated. Use Console.logger= instead."
 	end
 	
 	def logger
-		@logger || Logger.instance
-	end
-	
-	def self.extended(klass)
-		klass.instance_variable_set(:@logger, nil)
+		Logger.instance
 	end
 end

--- a/lib/console.rb
+++ b/lib/console.rb
@@ -19,10 +19,24 @@ module Console
 			Logger.instance= instance
 		end
 		
-		Logger::LEVELS.each do |name, level|
-			define_method(name) do |*arguments, **options, &block|
-				Logger.instance.send(name, *arguments, **options, &block)
-			end
+		def debug(...)
+			Logger.instance.debug(...)
+		end
+		
+		def info(...)
+			Logger.instance.info(...)
+		end
+		
+		def warn(...)
+			Logger.instance.warn(...)
+		end
+		
+		def error(...)
+			Logger.instance.error(...)
+		end
+		
+		def fatal(...)
+			Logger.instance.fatal(...)
 		end
 		
 		def call(...)
@@ -31,7 +45,7 @@ module Console
 	end
 	
 	def logger= logger
-		warn "Setting logger on #{self} is deprecated. Use Console.logger= instead."
+		warn "Setting logger on #{self} is deprecated. Use Console.logger= instead.", uplevel: 1
 	end
 	
 	def logger


### PR DESCRIPTION
When I first created this gem, I was focused on creating an object-centric interface. However, in practice, this is not useful. For the sake of compatibility and integration, a simple, standard interface is preferable.

Introduce `Console.info` and so on, which should redirect to whatever internal interface is appropriate.

Externally, code that needs to log things, should directly invoke the `Console#{level}` interface. We will also introduce documentation about the exact nature of that interface.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
