### PR TITLE
Introduce new "Safe" JSON serialization implementation.

### DIFF
--- a/lib/console/output/encoder.rb
+++ b/lib/console/output/encoder.rb
@@ -5,6 +5,7 @@
 
 module Console
 	module Output
+		# @deprecated With no replacement.
 		class Encoder
 			def initialize(output, encoding = ::Encoding::UTF_8)
 				@output = output

--- a/lib/console/output/json.rb
+++ b/lib/console/output/json.rb
@@ -4,16 +4,98 @@
 # Copyright, 2021-2022, by Samuel Williams.
 
 require_relative '../serialized/logger'
-require_relative 'encoder'
 
 module Console
 	module Output
 		module JSON
+			# This is a safe JSON serializer that will not raise exceptions.
+			class Safe
+				def initialize(limit: 8, encoding: ::Encoding::UTF_8)
+					@limit = limit
+					@encoding = encoding
+				end
+				
+				def dump(object)
+					::JSON.dump(object, @limit)
+				rescue => error
+					::JSON.dump(safe_dump(object, error))
+				end
+				
+				private
+				
+				def default_objects
+					Hash.new.compare_by_identity
+				end
+				
+				def safe_dump(object, error)
+					object = safe_dump_recurse(object)
+					
+					object[:truncated] = true
+					object[:error] = {
+						class: safe_dump_recurse(error.class.name),
+						message: safe_dump_recurse(error.message),
+					}
+					
+					return object
+				end
+				
+				def replacement_for(object)
+					case object
+					when Array
+						"[...]"
+					when Hash
+						"{...}"
+					else
+						"..."
+					end
+				end
+				
+				# This will recursively generate a safe version of the object.
+				# Nested hashes and arrays will be transformed recursively.
+				# Strings will be encoded with the given encoding.
+				# Primitive values will be returned as-is.
+				# Other values will be converted using `as_json` if available, otherwise `to_s`.
+				def safe_dump_recurse(object, limit = @limit, objects = default_objects)
+					if limit <= 0 || objects[object]
+						return replacement_for(object)
+					end
+					
+					case object
+					when Hash
+						objects[object] = true
+						
+						object.to_h do |key, value|
+							[
+								String(key).encode(@encoding, invalid: :replace, undef: :replace),
+								safe_dump_recurse(value, limit - 1, objects)
+							]
+						end
+					when Array
+						objects[object] = true
+						
+						object.map do |value|
+							safe_dump_recurse(value, limit - 1, objects)
+						end
+					when String
+						object.encode(@encoding, invalid: :replace, undef: :replace)
+					when Numeric, TrueClass, FalseClass, NilClass
+						object
+					else
+						objects[object] = true
+						
+						# We could do something like this but the chance `as_json` will blow up.
+						# We'd need to be extremely careful about it.
+						# if object.respond_to?(:as_json)
+						# 	safe_dump_recurse(object.as_json, limit - 1, objects)
+						# else
+						
+						safe_dump_recurse(object.to_s, limit - 1, objects)
+					end
+				end
+			end
+			
 			def self.new(output, **options)
-				# The output encoder can prevent encoding issues (e.g. invalid UTF-8):
-				Output::Encoder.new(
-					Serialized::Logger.new(output, format: ::JSON, **options)
-				)
+				Serialized::Logger.new(output, format: Safe.new, **options)
 			end
 		end
 	end


### PR DESCRIPTION
Introduce a "Safe" JSON serialization implementation:

1. Try to `JSON.dump(..., @limit)`, and if that fails
2. Walk over the object graph, replacing self-referential objects and mapping all keys/values to safe representations.

(2) is only done if (1) fails, so it should not affect the fast path as much.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
