### PR TITLE
Capture enough information to debug `SystemStackError`s when dumping logs.

### DIFF
--- a/test/console/format/safe.rb
+++ b/test/console/format/safe.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2021-2022, by Samuel Williams.
+
+require 'console/logger'
+require 'console/capture'
+require 'my_custom_output'
+
+class JSONHash < Hash
+	def to_json(options = nil)
+		::JSON.generate(self)
+	end
+end
+
+describe Console::Format::Safe do
+	let(:format) {subject.new}
+	let(:object) {JSONHash.new}
+	
+	it "can handle as_json raising SystemStackError" do
+		mock(object) do |mock|
+			mock.replace(:to_json) do
+				raise SystemStackError, "stack level too deep", 32.times.map{|i| "frame #{i}"}
+			end
+		end
+		
+		message = JSON.parse(
+			format.dump(object)
+		)
+		
+		expect(message).to have_keys(
+			'truncated' => be == true,
+			'error' => have_keys(
+				'class' => be == 'SystemStackError',
+				'message' => be =~ /stack level too deep/,
+			)
+		)
+		
+		backtrace = message['error']['backtrace']
+		expect(backtrace).to be_a(Array)
+		expect(backtrace.size).to be == Console::Format::Safe::MAXIMUM_FRAMES
+		inform(backtrace)
+	end
+end


### PR DESCRIPTION
Debugging errors that occur due to Rails' monkey patching of `JSON` behaviour can be exceedingly hard, so we introduce code to capture `SystemStackError` specifically and the relevant parts of the backtrace.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
