### PR TITLE
Convert annotation to string before printing.

### DIFF
--- a/lib/console/capture.rb
+++ b/lib/console/capture.rb
@@ -55,6 +55,10 @@ module Console
 				message[:arguments] = arguments
 			end
 			
+			if annotation = Fiber.current.annotation
+				message[:annotation] = annotation
+			end
+			
 			if block_given?
 				if block.arity.zero?
 					message[:message] = yield

--- a/lib/console/terminal/logger.rb
+++ b/lib/console/terminal/logger.rb
@@ -149,8 +149,14 @@ module Console
 				buffer = +""
 				
 				if @verbose
-					if annotation = Fiber.current.annotation and annotation.size > 0
-						buffer << ": #{@terminal[:annotation]}#{annotation}#{@terminal.reset}"
+					if annotation = Fiber.current.annotation
+						# While typically annotations should be strings, that is not always the case.
+						annotation = annotation.to_s
+						
+						# If the annotation is empty, we don't want to print it, as it will look like a formatting bug.
+						if annotation.size > 0
+							buffer << ": #{@terminal[:annotation]}#{annotation}#{@terminal.reset}"
+						end
 					end
 				end
 				

--- a/test/console/logger.rb
+++ b/test/console/logger.rb
@@ -154,4 +154,19 @@ describe Console::Logger do
 			expect(Console::Logger.default_log_level({'CONSOLE_LEVEL' => 'debug'})).to be == Console::Logger::DEBUG
 		end
 	end
+	
+	with "Fiber annotation" do
+		it "logs fiber annotations" do
+			Fiber.new do
+				Fiber.annotate("Running in a fiber.")
+				
+				logger.info(message)
+			end.resume
+			
+			expect(output.last).to have_keys(
+				annotation: be == "Running in a fiber.",
+				subject: be == "Hello World",
+			)
+		end
+	end
 end

--- a/test/console/serialized/logger.rb
+++ b/test/console/serialized/logger.rb
@@ -59,4 +59,34 @@ describe Console::Serialized::Logger do
 			expect(error_message).to have_keys(:kind, :message, :stack)
 		end
 	end
+	
+	with "Fiber annotation" do
+		it "logs fiber annotations" do
+			Fiber.new do
+				Fiber.annotate("Running in a fiber.")
+				
+				logger.call(message)
+			end.resume
+			
+			expect(record).to have_keys(
+				annotation: be == "Running in a fiber.",
+				subject: be == "Hello World",
+			)
+		end
+		
+		it "logs fiber annotations when it isn't a string" do
+			thing = ["Running in a fiber."]
+			
+			Fiber.new do
+				Fiber.annotate(thing)
+				
+				logger.call(message)
+			end.resume
+			
+			expect(record).to have_keys(
+				annotation: be == thing,
+				subject: be == "Hello World",
+			)
+		end
+	end
 end

--- a/test/console/terminal/logger.rb
+++ b/test/console/terminal/logger.rb
@@ -35,4 +35,28 @@ describe Console::Terminal::Logger do
 			expect(io.string).to be(:include?, message)
 		end
 	end
+	
+	with "Fiber annotation" do
+		it "logs fiber annotations" do
+			Fiber.new do
+				Fiber.annotate("Running in a fiber.")
+				
+				logger.call(message)
+			end.resume
+			
+			expect(io.string).to be(:include?, "Running in a fiber.")
+		end
+		
+		it "logs fiber annotations when it isn't a string" do
+			thing = ["Running in a fiber."]
+			
+			Fiber.new do
+				Fiber.annotate(thing)
+				
+				logger.call(message)
+			end.resume
+			
+			expect(io.string).to be(:include?, thing.to_s)
+		end
+	end
 end


### PR DESCRIPTION
In some cases, a fiber may be annotated with a rich object that responds to `#to_s`. So, don't assume it's a String, and convert it if necessary.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
