### PR TITLE
Disable usage of `Ractor.make_shareable` on Ruby 3.0 as it's broken on Ruby 3.0.2.

### DIFF
--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -12,7 +12,7 @@ module Console
 	UNKNOWN = 'unknown'
 	
 	class Filter
-		if Object.const_defined?(:Ractor)
+		if Object.const_defined?(:Ractor) and RUBY_VERSION >= '3.1'
 			def self.define_immutable_method(name, &block)
 				block = Ractor.make_shareable(block)
 				self.define_method(name, &block)


### PR DESCRIPTION
The following test code demonstrates the problem:

```ruby
#!/usr/bin/env ruby

class Object
	if const_defined?(:Ractor)
		def self.define_immutable_method(name, &block)
			block = Ractor.make_shareable(block)
			self.define_method(name, &block)
		end
	else
		def self.define_immutable_method(name, &block)
			define_method(name, &block)
		end
	end
	
	def self.[] **levels
		klass = Class.new(self)
		
		klass.instance_exec do
			levels.each do |name, level|
				define_immutable_method(name) do
					puts severity: name, level: level
				end
			end
		end
		
		return klass
	end
end

Filter = Object[info: 0, debug: 2]

filter = Filter.new

filter.info
filter.debug
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
