### PR TITLE
Prefer exception detailed message

### DIFF
--- a/lib/console/event/failure.rb
+++ b/lib/console/event/failure.rb
@@ -44,7 +44,7 @@ module Console
 			end
 			
 			def format_exception(exception, prefix, output, terminal, verbose)
-				lines = exception.message.lines.map(&:chomp)
+				lines = exception.detailed_message.lines.map(&:chomp)
 				
 				output.puts "  #{prefix}#{terminal[:exception_title]}#{exception.class}#{terminal.reset}: #{lines.shift}"
 				


### PR DESCRIPTION
Improve formatting of exceptions using `detailed_message`.

We may want to feature detect to be compatible with Ruby 3.0.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
