### PR TITLE
Add compatible shim for `Exception#detailed_message`.

### DIFF
--- a/lib/console/event/failure.rb
+++ b/lib/console/event/failure.rb
@@ -43,8 +43,18 @@ module Console
 				format_exception(@exception, nil, output, terminal, verbose)
 			end
 			
+			if Exception.method_defined?(:detailed_message)
+				def detailed_message(exception)
+					exception.detailed_message
+				end
+			else
+				def detailed_message(exception)
+					exception.message
+				end
+			end
+			
 			def format_exception(exception, prefix, output, terminal, verbose)
-				lines = exception.message.lines.map(&:chomp)
+				lines = detailed_message(exception).lines.map(&:chomp)
 				
 				output.puts "  #{prefix}#{terminal[:exception_title]}#{exception.class}#{terminal.reset}: #{lines.shift}"
 				

--- a/test/console/event/failure.rb
+++ b/test/console/event/failure.rb
@@ -7,42 +7,70 @@
 require 'console'
 require 'console/capture'
 
+class TestError < StandardError
+	def detailed_message(...)
+		"#{super}\nwith details"
+	end
+end
+
 describe Console::Event::Failure do
 	let(:output) {StringIO.new}
 	let(:terminal) {Console::Terminal.for(output)}
-	let(:error) {
-		RuntimeError.new("Test").tap {|e|
-			e.set_backtrace([
-				"(irb):2:in `rescue in irb_binding'",
-				"(irb):1:in `irb_binding'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `eval'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `evaluate'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/context.rb:450:in `evaluate'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:541:in `block (2 levels) in eval_input'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:704:in `signal_status'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:538:in `block in eval_input'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:166:in `block (2 levels) in each_top_level_statement'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `loop'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `block in each_top_level_statement'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `catch'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `each_top_level_statement'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:537:in `eval_input'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:472:in `block in run'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `catch'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `run'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:400:in `start'",
-				"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/exe/irb:11:in `<top (required)>'",
-				"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `load'",
-				"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `<main>'"
-			])
-		}
-	}
 	
-	it "formats exception removing root path" do
-		event = Console::Event::Failure.new(error, "/path/to/root")
-		event.format(output, terminal, true)
-		expect(output.string.lines[3..-1]).to have(
-			Sus::Have::Value.new(be =~ /^\s+\.gem/)
-		)
+	with 'runtime error' do
+		let(:error) do
+			RuntimeError.new("Test").tap do |error|
+				error.set_backtrace([
+					"(irb):2:in `rescue in irb_binding'",
+					"(irb):1:in `irb_binding'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `eval'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/workspace.rb:114:in `evaluate'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/context.rb:450:in `evaluate'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:541:in `block (2 levels) in eval_input'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:704:in `signal_status'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:538:in `block in eval_input'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:166:in `block (2 levels) in each_top_level_statement'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `loop'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:151:in `block in each_top_level_statement'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `catch'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb/ruby-lex.rb:150:in `each_top_level_statement'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:537:in `eval_input'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:472:in `block in run'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `catch'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:471:in `run'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/lib/irb.rb:400:in `start'",
+					"/path/to/root/.gem/ruby/2.5.7/gems/irb-1.2.7/exe/irb:11:in `<top (required)>'",
+					"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `load'",
+					"/path/to/root/.gem/ruby/2.5.7/bin/irb:23:in `<main>'"
+				])
+			end
+		end
+		
+		it "formats exception removing root path" do
+			event = Console::Event::Failure.new(error, "/path/to/root")
+			event.format(output, terminal, true)
+			expect(output.string.lines[3..-1]).to have_value(be =~ /^\s+\.gem/)
+		end
+	end
+	
+	with 'test error' do
+		let(:error) do
+			begin
+				raise TestError, "Test error!"
+			rescue TestError => error
+				error
+			end
+		end
+		
+		it "includes detailed message" do
+			skip_unless_method_defined(:detailed_message, Exception)
+			
+			expect(error.detailed_message).to be =~ /with details/
+			
+			event = Console::Event::Failure.new(error)
+			event.format(output, terminal, true)
+			expect(output.string).to be =~ /Test error!/
+			expect(output.string).to be =~ /with details/
+		end
 	end
 end


### PR DESCRIPTION
Extend the formatted error output to include `detailed_message` if present.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
