### PR TITLE
Use fiber storage for console instance so that it can be shared to child fibers/threads.

### DIFF
--- a/console.gemspec
+++ b/console.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.0"
 	
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "fiber-local"
+	spec.add_dependency "fiber-storage"
 	spec.add_dependency "json"
 end

--- a/lib/console/logger.rb
+++ b/lib/console/logger.rb
@@ -13,12 +13,10 @@ require_relative 'resolver'
 require_relative 'terminal/logger'
 require_relative 'serialized/logger'
 
-require 'fiber/local'
+require 'fiber/storage'
 
 module Console
 	class Logger < Filter[debug: 0, info: 1, warn: 2, error: 3, fatal: 4]
-		extend Fiber::Local
-		
 		# Set the default log level based on `$DEBUG` and `$VERBOSE`.
 		# You can also specify CONSOLE_LEVEL=debug or CONSOLE_LEVEL=info in environment.
 		# https://mislav.net/2011/06/ruby-verbose-mode/ has more details about how it all fits together.
@@ -56,8 +54,12 @@ module Console
 			return logger
 		end
 		
-		def self.local
-			self.default_logger
+		def self.instance
+			Fiber[:console_logger] ||= self.default_logger
+		end
+		
+		def self.instance=(logger)
+			Fiber[:console_logger] = logger
 		end
 		
 		DEFAULT_LEVEL = 1

--- a/test/console/logger.rb
+++ b/test/console/logger.rb
@@ -15,6 +15,22 @@ describe Console::Logger do
 	
 	let(:message) {"Hello World"}
 	
+	with '.instance' do
+		it "propagates to child thread" do
+			Fiber.new do
+				expect(Fiber[:console_logger]).to be_nil
+				
+				logger = Console::Logger.instance
+				
+				Fiber.new do
+					expect(Console::Logger.instance).to be_equal(logger)
+				end.resume
+			end.resume
+			
+			expect(Fiber[:console_logger]).to be_nil
+		end
+	end
+	
 	with '#with' do
 		let(:nested) {logger.with(name: "nested", level: :debug)}
 		


### PR DESCRIPTION
The console gem creates unique logger instance per thread at least.

However, this is a little inefficient and also cause some confusion around mutation of logger instances.

In general, logger instance should not be directly mutated, as it's not generally thread safe (we may need to consider how to best enforce this). In other words, the environment variables are better for controlling the default logger.

One option is to freeze the logger on assignment - forcing users to re-assign, e.g.

```ruby
# Bad - logger instance might be shared between threads:
Console::Logger.instance.verbose! # FrozenError

# Okay - prevent mutation of shared state:
logger = Console::Logger.instance.dup
logger.verbose!
Console::Logger.instance = logger
```

But at program initialization, if the environment variables can't be controlled, an alternative is to modify the top level console logger, which will propagate to all child threads/fibers.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
