### PR TITLE
Event::Failure: add #exception

### DIFF
--- a/lib/console/event/failure.rb
+++ b/lib/console/event/failure.rb
@@ -27,7 +27,9 @@ module Console
 			def self.log(subject, exception, **options)
 				Console.error(subject, **self.for(exception).to_hash, **options)
 			end
-			
+
+			attr_reader :exception
+
 			def initialize(exception, root = Dir.getwd)
 				@exception = exception
 				@root = root

--- a/test/console/event/failure.rb
+++ b/test/console/event/failure.rb
@@ -53,5 +53,11 @@ describe Console::Event::Failure do
 				)
 			)
 		end
+
+		it "can get #exception" do
+			failure = Console::Event::Failure.for(error)
+			
+			expect(failure.exception).to be == error
+		end
 	end
 end


### PR DESCRIPTION
I needed access to the exception in an output wrapper.