### PR TITLE
Logging returns `true`

### DIFF
--- a/lib/console/capture.rb
+++ b/lib/console/capture.rb
@@ -95,6 +95,7 @@ module Console
 			end
 			
 			@records << record
+			true
 		end
 	end
 end

--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -34,9 +34,9 @@ module Console
 					const_set(name.to_s.upcase, level)
 					
 					define_immutable_method(name) do |subject = nil, *arguments, **options, &block|
-						if self.enabled?(subject, level)
-							@output.call(subject, *arguments, severity: name, **@options, **options, &block)
-						end
+						return true unless self.enabled?(subject, level)
+						
+						@output.call(subject, *arguments, severity: name, **@options, **options, &block)
 					end
 					
 					define_immutable_method("#{name}!") do
@@ -147,9 +147,9 @@ module Console
 			severity = options[:severity] || UNKNOWN
 			level = self.class::LEVELS[severity]
 			
-			if self.enabled?(subject, level)
-				@output.call(subject, *arguments, **options, &block)
-			end
+			return true unless self.enabled?(subject, level)
+			
+			@output.call(subject, *arguments, **options, &block)
 		end
 	end
 end

--- a/lib/console/output/null.rb
+++ b/lib/console/output/null.rb
@@ -15,6 +15,7 @@ module Console
 			
 			def call(...)
 				# Do nothing.
+				true
 			end
 		end
 	end

--- a/lib/console/output/serialized.rb
+++ b/lib/console/output/serialized.rb
@@ -69,6 +69,7 @@ module Console
 				record.update(options)
 				
 				@io.puts(self.dump(record))
+				true
 			end
 		end
 		

--- a/lib/console/output/split.rb
+++ b/lib/console/output/split.rb
@@ -22,6 +22,7 @@ module Console
 				@outputs.each do |output|
 					output.call(...)
 				end
+				true
 			end
 		end
 	end

--- a/lib/console/output/terminal.rb
+++ b/lib/console/output/terminal.rb
@@ -135,6 +135,7 @@ module Console
 				end
 				
 				@io.write buffer.string
+				true
 			end
 			
 			protected

--- a/test/console/filter.rb
+++ b/test/console/filter.rb
@@ -24,6 +24,10 @@ describe Console::Filter do
 			logger.info(MySubject, "Hello World")
 			expect(output).to be(:empty?)
 		end
+
+		it "should return true" do
+			expect(logger.info(MySubject, "test")).to be == true
+		end
 		
 		with "#enable" do
 			def before
@@ -70,25 +74,28 @@ describe Console::Filter do
 		it "ignores messages below the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :debug)
+			result = logger.call(MySubject, "Hello World", severity: :debug)
 			
 			expect(output).to be(:empty?)
+			expect(result).to be == true
 		end
 		
 		it "logs messages at the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :info)
+			result = logger.call(MySubject, "Hello World", severity: :info)
 			
 			expect(output).to be(:include?, "Hello World")
+			expect(result).to be == true
 		end
 		
 		it "logs messages above the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :warn)
+			result = logger.call(MySubject, "Hello World", severity: :warn)
 			
 			expect(output).to be(:include?, "Hello World")
+			expect(result).to be == true
 		end
 	end
 end

--- a/test/console/output/default.rb
+++ b/test/console/output/default.rb
@@ -13,4 +13,8 @@ describe Console::Output::Default do
 	it "should output to $stderr by default" do
 		expect(output.last_output.io).to be == $stderr
 	end
+	
+	it "should return true" do
+		expect(output.call("test")).to be == true
+	end
 end

--- a/test/console/output/sensitive.rb
+++ b/test/console/output/sensitive.rb
@@ -24,6 +24,10 @@ describe Console::Output::Sensitive do
 		expect(output).not.to be(:include?, "Samuel Williams")
 	end
 	
+	it "should return true" do
+		expect(logger.call("test")).to be == true
+	end
+	
 	with "sensitive: false" do
 		it "bypasses redaction" do
 			logger.call("first_name: Samuel Williams", sensitive: false)

--- a/test/console/output/serialized.rb
+++ b/test/console/output/serialized.rb
@@ -33,6 +33,10 @@ describe Console::Output::Serialized do
 		)
 	end
 	
+	it "should return true" do
+		expect(logger.call(message)).to be == true
+	end
+	
 	with "structured event" do
 		let(:event) {Console::Event::Spawn.for("ls -lah")}
 		

--- a/test/console/output/split.rb
+++ b/test/console/output/split.rb
@@ -23,4 +23,8 @@ describe Console::Output::Split do
 		expect(outputs[0].verbose?).to be == true
 		expect(outputs[1].verbose?).to be == true
 	end
+	
+	it "should return true" do
+		expect(logger.call("test")).to be == true
+	end
 end

--- a/test/console/output/terminal.rb
+++ b/test/console/output/terminal.rb
@@ -27,6 +27,10 @@ describe Console::Output::Terminal do
 		expect(io.string).to be =~ /"foo": "bar"/
 	end
 	
+	it "should return true" do
+		expect(logger.call(message)).to be == true
+	end
+	
 	with "verbose: false" do
 		let(:logger) {subject.new(io, verbose: false)}
 		


### PR DESCRIPTION
See #64 

## Types of Changes

- Logging methods (like `Console.info`) consistently return `true` regardless of Output
 
## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
