### PR TITLE
Always return `nil`.

### DIFF
--- a/lib/console/filter.rb
+++ b/lib/console/filter.rb
@@ -37,6 +37,8 @@ module Console
 						if self.enabled?(subject, level)
 							@output.call(subject, *arguments, severity: name, **@options, **options, &block)
 						end
+						
+						return nil
 					end
 					
 					define_immutable_method("#{name}!") do
@@ -150,6 +152,8 @@ module Console
 			if self.enabled?(subject, level)
 				@output.call(subject, *arguments, **options, &block)
 			end
+			
+			return nil
 		end
 	end
 end

--- a/test/console/filter.rb
+++ b/test/console/filter.rb
@@ -66,29 +66,52 @@ describe Console::Filter do
 		end
 	end
 	
-	with "#call" do
+	with "#info" do
 		it "ignores messages below the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :debug)
+			result = logger.debug(MySubject, "Hello World")
 			
 			expect(output).to be(:empty?)
+			expect(result).to be_nil
 		end
 		
 		it "logs messages at the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :info)
+			result = logger.info(MySubject, "Hello World", severity: :info)
 			
 			expect(output).to be(:include?, "Hello World")
+			expect(result).to be_nil
+		end
+	end
+	
+	with "#call" do
+		it "ignores messages below the level" do
+			logger.level = Console::Logger::INFO
+			
+			result = logger.call(MySubject, "Hello World", severity: :debug)
+			
+			expect(output).to be(:empty?)
+			expect(result).to be_nil
+		end
+		
+		it "logs messages at the level" do
+			logger.level = Console::Logger::INFO
+			
+			result = logger.call(MySubject, "Hello World", severity: :info)
+			
+			expect(output).to be(:include?, "Hello World")
+			expect(result).to be_nil
 		end
 		
 		it "logs messages above the level" do
 			logger.level = Console::Logger::INFO
 			
-			logger.call(MySubject, "Hello World", severity: :warn)
+			result = logger.call(MySubject, "Hello World", severity: :warn)
 			
 			expect(output).to be(:include?, "Hello World")
+			expect(result).to be_nil
 		end
 	end
 end


### PR DESCRIPTION
See <https://github.com/socketry/console/pull/65> for context/discussion.

Essentially, `Console.info` (or any level/`#call`) should always return `nil` (or in general, be consistent in it's return value).

You should not use `Console...` as part of a conditional IMHO. Returning `nil` will prevent this.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
