### PR TITLE
Add support for loading `CONSOLE_OUTPUT` constants.

### DIFF
--- a/lib/console/output.rb
+++ b/lib/console/output.rb
@@ -10,12 +10,43 @@ require_relative "output/null"
 
 module Console
 	module Output
+		# Convert a constant name like `Foo::Bar` to a path like `foo/bar`.
+		#
+		# @parameter name [String] The constant name.
+		# @returns [String] The path.
+		def self.to_path(name)
+			path = name.gsub("::", "/")
+			
+			# Insert underscore between acronym and normal words
+			path.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+			
+			# Insert underscore between lowercase and uppercase letters:
+			path.gsub!(/(?<=[a-z0-9])([A-Z])/, '_\1')
+			path.downcase!
+			
+			return path
+		end
+		
+		# Load a constant by name. May require the file if it is not already loaded.
+		#
+		# @parameter name [String] The constant name.
+		# @returns [Class] The constant.
+		def self.load(name)
+			Output.const_get(name)
+		rescue NameError
+			begin
+				require(to_path(name))
+			ensure
+				Output.const_get(name)
+			end
+		end
+		
 		def self.new(output = nil, env = ENV, **options)
 			if names = env["CONSOLE_OUTPUT"]
 				names = names.split(",").reverse
 				
 				names.inject(output) do |output, name|
-					Output.const_get(name).new(output, **options)
+					load(name).new(output, **options)
 				end
 			else
 				return Output::Default.new(output, **options)

--- a/test/console/output.rb
+++ b/test/console/output.rb
@@ -12,7 +12,31 @@ describe Console::Output do
 	let(:env) {Hash.new}
 	let(:output) {Console::Output.new(capture, env)}
 	
-	describe ".new" do
+	with ".to_path" do
+		it "should convert constant name to path" do
+			expect(subject.to_path("Foo")).to be == "foo"
+			expect(subject.to_path("Foo::Bar")).to be == "foo/bar"
+			expect(subject.to_path("FooBar")).to be == "foo_bar"
+			expect(subject.to_path("Foo::BarBaz")).to be == "foo/bar_baz"
+			expect(subject.to_path("Foo::HTTPBar")).to be == "foo/http_bar"
+		end
+	end
+	
+	with ".load" do
+		it "should load a constant by name" do
+			expect(subject.load("Default")).to be == Console::Output::Default
+		end
+		
+		it "can require the file if it is not already loaded" do
+			expect(subject).to receive(:require).with("console/output/foo_bar")
+			
+			expect do
+				subject.load("Console::Output::FooBar")
+			end.to raise_exception(NameError)
+		end
+	end
+	
+	with ".new" do
 		with "output to a file" do
 			let(:capture) {File.open("/tmp/console.log", "w")}
 			


### PR DESCRIPTION
This allows `CONSOLE_OUTPUT` to dynamically load Ruby files according to the constant path.

I'm a little concerned about scope creep and security. I'm going to explore alternatives.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
