### PR TITLE
Introduce `Console::Config` for better control over initial setup.

### DIFF
--- a/lib/console/config.rb
+++ b/lib/console/config.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require_relative "filter"
+require_relative "event"
+require_relative "resolver"
+require_relative "output"
+require_relative "logger"
+
+module Console
+	# Represents a configuration for the traces library.
+	class Config
+		PATH = ENV.fetch("CONSOLE_CONFIG_PATH", "config/console.rb")
+		
+		# Load the configuration from the given path.
+		# @parameter path [String] The path to the configuration file.
+		# @returns [Config] The loaded configuration.
+		def self.load(path)
+			config = self.new
+			
+			if File.exist?(path)
+				config.instance_eval(File.read(path), path)
+			end
+			
+			return config
+		end
+		
+		# Load the default configuration.
+		# @returns [Config] The default configuration.
+		def self.default
+			@default ||= self.load(PATH)
+		end
+		
+		# Set the default log level based on `$DEBUG` and `$VERBOSE`.
+		# You can also specify CONSOLE_LEVEL=debug or CONSOLE_LEVEL=info in environment.
+		# https://mislav.net/2011/06/ruby-verbose-mode/ has more details about how it all fits together.
+		def log_level(env = ENV)
+			Logger.default_log_level(env)
+		end
+		
+		# Controls verbose output using `$VERBOSE`.
+		def verbose?(env = ENV)
+			!$VERBOSE.nil? || env["CONSOLE_VERBOSE"]
+		end
+		
+		# Create an output with the given output and options.
+		#
+		# @parameter output [IO] The output to write log messages to.
+		# @parameter env [Hash] The environment to read configuration from.
+		# @parameter options [Hash] Additional options to pass to the output.
+		# @returns [Output] The created output.
+		def make_output(io = nil, env = ENV, **options)
+			Output.new(io, env, **options)
+		end
+		
+		# Create a resolver with the given logger.
+		#
+		# @parameter logger [Logger] The logger to set the log levels on.
+		# @returns [Resolver | Nil] The created resolver.
+		def make_resolver(logger)
+			Resolver.default_resolver(logger)
+		end
+		
+		# Create a logger with the given output and options.
+		#
+		# @parameter output [IO] The output to write log messages to.
+		# @parameter env [Hash] The environment to read configuration from.
+		# @parameter options [Hash] Additional options to pass to the logger.
+		# @returns [Logger] The created logger.
+		def make_logger(io = $stderr, env = ENV, **options)
+			if options[:verbose].nil?
+				options[:verbose] = self.verbose?(env)
+			end
+			
+			if options[:level].nil?
+				options[:level] = self.log_level(env)
+			end
+			
+			output = self.make_output(io, env, **options)
+			
+			logger = Logger.new(output, **options)
+			
+			make_resolver(logger)
+			
+			return logger
+		end
+		
+		# Load the default configuration.
+		DEFAULT = self.default
+	end
+end

--- a/lib/console/interface.rb
+++ b/lib/console/interface.rb
@@ -3,51 +3,59 @@
 # Released under the MIT License.
 # Copyright, 2024-2025, by Samuel Williams.
 
-require_relative "logger"
+require "fiber/local"
+require_relative "config"
 
 module Console
 	# The public logger interface.
 	module Interface
+		extend Fiber::Local
+		
+		# Create a new (thread local) logger instance.
+		def self.local
+			Config::DEFAULT.make_logger
+		end
+		
 		# Get the current logger instance.
 		def logger
-			Logger.instance
+			Interface.instance
 		end
 		
 		# Set the current logger instance.
 		#
 		# The current logger instance is assigned per-fiber.
 		def logger= instance
-			Logger.instance= instance
+			Interface.instance= instance
 		end
 		
 		# Emit a debug log message.
 		def debug(...)
-			Logger.instance.debug(...)
+			Interface.instance.debug(...)
 		end
 		
 		# Emit an informational log message.
 		def info(...)
-			Logger.instance.info(...)
+			Interface.instance.info(...)
 		end
 		
 		# Emit a warning log message.
 		def warn(...)
-			Logger.instance.warn(...)
+			Interface.instance.warn(...)
 		end
 		
 		# Emit an error log message.
 		def error(...)
-			Logger.instance.error(...)
+			Interface.instance.error(...)
 		end
 		
 		# Emit a fatal log message.
 		def fatal(...)
-			Logger.instance.fatal(...)
+			Interface.instance.fatal(...)
 		end
 		
 		# Emit a log message with arbitrary arguments and options.
 		def call(...)
-			Logger.instance.call(...)
+			Interface.instance.call(...)
 		end
 	end
 end

--- a/lib/console/logger.rb
+++ b/lib/console/logger.rb
@@ -8,20 +8,14 @@
 require_relative "output"
 require_relative "output/failure"
 
-require_relative "filter"
-require_relative "event"
-require_relative "resolver"
 require_relative "progress"
-
-require "fiber/local"
+require_relative "config"
 
 module Console
 	# The standard logger interface with support for log levels and verbosity.
 	#
 	# The log levels are: `debug`, `info`, `warn`, `error`, and `fatal`.
 	class Logger < Filter[debug: 0, info: 1, warn: 2, error: 3, fatal: 4]
-		extend Fiber::Local
-		
 		# Set the default log level based on `$DEBUG` and `$VERBOSE`.
 		# You can also specify CONSOLE_LEVEL=debug or CONSOLE_LEVEL=info in environment.
 		# https://mislav.net/2011/06/ruby-verbose-mode/ has more details about how it all fits together.
@@ -35,35 +29,6 @@ module Console
 			else
 				INFO
 			end
-		end
-		
-		# Controls verbose output using `$VERBOSE`.
-		def self.verbose?(env = ENV)
-			!$VERBOSE.nil? || env["CONSOLE_VERBOSE"]
-		end
-		
-		# Construct a new default logger.
-		def self.default_logger(output = $stderr, env = ENV, **options)
-			if options[:verbose].nil?
-				options[:verbose] = self.verbose?(env)
-			end
-			
-			if options[:level].nil?
-				options[:level] = self.default_log_level(env)
-			end
-			
-			output = Output.new(output, env, **options)
-			
-			logger = self.new(output, **options)
-			
-			Resolver.default_resolver(logger)
-			
-			return logger
-		end
-		
-		# Construct a new fiber-local logger.
-		def self.local
-			self.default_logger
 		end
 		
 		DEFAULT_LEVEL = 1

--- a/lib/console/warn.rb
+++ b/lib/console/warn.rb
@@ -22,7 +22,7 @@ module Console
 				fiber.console_warn = true
 				message.chomp!
 				
-				Console::Logger.instance.warn(message, **options)
+				Console::Interface.instance.warn(message, **options)
 			ensure
 				fiber.console_warn = false
 			end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,28 @@
 # Releases
 
+## Unreleased
+
+### Introduce `Console::Config` for fine grained configuration.
+
+Introduced a new explicit configuration interface via config/console.rb to enhance logging setup in complex applications. This update gives the application code an opportunity to load files if required and control aspects such as log level, output, and more. Users can override default behaviors (e.g., make_output, make_logger, and log_level) for improved customization.
+
+```ruby 
+# config/console.rb
+def log_level(env = ENV)
+	# Set a custom log level, e.g., force debug mode:
+	:debug
+end
+
+def make_logger(output = $stderr, env = ENV, **options)
+	# Custom logger configuration with verbose output:
+	options[:verbose] = true
+	
+	 Logger.new(output, **options)
+end
+```
+
+This approach provides a standard way to hook into the log setup process, allowing tailored adjustments for reliable and customizable logging behavior.
+
 ## v1.29.3
 
   - Serialized output now uses `IO#write` with a single string to reduce the chance of interleaved output.
@@ -17,7 +40,7 @@
   - Don't make `Kernel#warn` redirection to `Console.warn` the default behavior, you must `require 'console/warn'` to enable it.
   - Remove deprecated `Console::Logger#failure`.
 
-### Consistent Handling of Exceptions
+### Consistent handling of exceptions.
 
 `Console.call` and all wrapper methods will now consistently handle exceptions that are the last positional argument or keyword argument. This means that the following code will work as expected:
 

--- a/test/console/config.rb
+++ b/test/console/config.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022-2023, by Samuel Williams.
+
+require "console/config"
+
+describe Console::Config do
+	let(:config) {subject.new}
+	
+	with "#make_output" do
+		it "can create an output" do
+			output = config.make_output
+			
+			expect(output).to be(:respond_to?, :call)
+		end
+	end
+	
+	with "#make_logger" do
+		it "can create a logger" do
+			logger = config.make_logger
+			
+			expect(logger).to be_a Console::Logger
+		end
+	end
+end

--- a/test/console/interface.rb
+++ b/test/console/interface.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2019-2024, by Samuel Williams.
+# Copyright, 2019, by Bryan Powell.
+# Copyright, 2020, by Michael Adams.
+# Copyright, 2021, by Robert Schulze.
+
+require "console/interface"
+
+describe Console::Interface do
+	with ".instance" do
+		it "propagates to child thread" do
+			Fiber.new do
+				logger = Console::Interface.instance
+				
+				Fiber.new do
+					expect(Console::Interface.instance).to be_equal(logger)
+				end.resume
+			end.resume
+		end
+	end
+end

--- a/test/console/logger.rb
+++ b/test/console/logger.rb
@@ -15,18 +15,6 @@ describe Console::Logger do
 	
 	let(:message) {"Hello World"}
 	
-	with ".instance" do
-		it "propagates to child thread" do
-			Fiber.new do
-				logger = Console::Logger.instance
-				
-				Fiber.new do
-					expect(Console::Logger.instance).to be_equal(logger)
-				end.resume
-			end.resume
-		end
-	end
-	
 	with "#with" do
 		let(:nested) {logger.with(name: "nested", level: :debug)}
 		

--- a/test/console/output.rb
+++ b/test/console/output.rb
@@ -12,7 +12,7 @@ describe Console::Output do
 	let(:env) {Hash.new}
 	let(:output) {Console::Output.new(capture, env)}
 	
-	describe ".new" do
+	with ".new" do
 		with "output to a file" do
 			let(:capture) {File.open("/tmp/console.log", "w")}
 			


### PR DESCRIPTION
It's tricky to specify `CONSOLE_OUTPUT` in more complex applications. In particular, if classes are specified in `CONSOLE_OUTPUT` that aren't defined yet, logging can fail.

By providing `config/console.rb`, you can hook into the log setup process, ensuring that relevant files are loaded, and overriding default behaviours like `make_output`, `make_logger` and `log_level`.

This is a more "explicit" alternative to <https://github.com/socketry/console/pull/69>, in the sense that there is no automatic `require`s, and instead provides a standard interface `config/console.rb` that the user can implement.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
