### PR TITLE
Terminal::Text: print style reset before newline

### DIFF
--- a/lib/console/terminal/text.rb
+++ b/lib/console/terminal/text.rb
@@ -78,15 +78,19 @@ module Console
 				end
 			end
 			
-			# Write the given arguments to the output stream using the given style. The reset sequence is automatically appended.
+			# Write the given arguments to the output stream using the given style. The reset sequence is automatically
+			# appended at the end of each line.
 			#
 			# @parameter arguments [Array] The arguments to write, each on a new line.
 			# @parameter style [Symbol] The style to apply.
 			def puts(*arguments, style: nil)
 				if style and prefix = self[style]
-					@stream.write(prefix)
-					@stream.puts(*arguments)
-					@stream.write(self.reset)
+					arguments.each do |argument|
+						argument.to_s.lines.each do |line|
+							@stream.write(prefix, line.chomp)
+							@stream.puts(self.reset)
+						end
+					end
 				else
 					@stream.puts(*arguments)
 				end

--- a/test/console/terminal/xterm.rb
+++ b/test/console/terminal/xterm.rb
@@ -30,7 +30,16 @@ describe Console::Terminal::XTerm do
 		
 		terminal.puts("Hello World", style: :bold)
 		
-		expect(stream.string.split(/\r?\n/)).to be == ["\e[1mHello World", "\e[0m"]
+		expect(stream.string.chomp).to be == "\e[1mHello World\e[0m"
+		expect(stream.string).to be =~ /\r?\n\z/
+	end
+
+	it "can puts multiline text with specified style" do
+		terminal[:bold] = terminal.style(nil, nil, :bold)
+		
+		terminal.puts("Hello\nWorld", style: :bold)
+		
+		expect(stream.string.split(/\r?\n/)).to be == ["\e[1mHello\e[0m", "\e[1mWorld\e[0m"]
 	end
 	
 	with "#print" do


### PR DESCRIPTION
This fixes #75

Not sure if this is up to your standards. By calling `#to_s` on each argument, I tried to mimic `IO#puts`.