### PR TITLE
Align decimals in elapsed time display

### DIFF
--- a/lib/console/clock.rb
+++ b/lib/console/clock.rb
@@ -12,7 +12,7 @@ module Console
 		# @returns [String] The formatted duration.
 		def self.formatted_duration(duration)
 			if duration < 60.0
-				return "#{format("%.2f", duration)}s"
+				return format("%.2fs", duration)
 			end
 			
 			duration /= 60.0

--- a/lib/console/clock.rb
+++ b/lib/console/clock.rb
@@ -12,7 +12,7 @@ module Console
 		# @returns [String] The formatted duration.
 		def self.formatted_duration(duration)
 			if duration < 60.0
-				return "#{duration.round(2)}s"
+				return "#{format("%.2f", duration)}s"
 			end
 			
 			duration /= 60.0

--- a/test/console/clock.rb
+++ b/test/console/clock.rb
@@ -8,11 +8,13 @@ require "console/clock"
 describe Console::Clock do
 	with ".formatted_duration" do
 		it "can format seconds" do
-			expect(subject.formatted_duration(0)).to be == "0s"
-			expect(subject.formatted_duration(1)).to be == "1s"
-			expect(subject.formatted_duration(2)).to be == "2s"
-			expect(subject.formatted_duration(10)).to be == "10s"
-			expect(subject.formatted_duration(59)).to be == "59s"
+			expect(subject.formatted_duration(0)).to be == "0.00s"
+			expect(subject.formatted_duration(0.5)).to be == "0.50s"
+			expect(subject.formatted_duration(0.667)).to be == "0.67s"
+			expect(subject.formatted_duration(1)).to be == "1.00s"
+			expect(subject.formatted_duration(2)).to be == "2.00s"
+			expect(subject.formatted_duration(10)).to be == "10.00s"
+			expect(subject.formatted_duration(59)).to be == "59.00s"
 		end
 		
 		it "can format minutes" do

--- a/test/progress.rb
+++ b/test/progress.rb
@@ -67,7 +67,7 @@ describe Console::Progress do
 			expect(console_capture.last).to have_keys(
 				severity: be == :info,
 				subject: be == "My Measurement",
-				arguments: have_attributes(first: be =~ /100\/100 completed in .*?, 0.0s remaining\./),
+				arguments: have_attributes(first: be =~ /100\/100 completed in .*?, 0\.00s remaining\./),
 				event: have_keys(
 					type: be == :progress,
 					current: be == 100,


### PR DESCRIPTION
Suggest to change the elapsed time format so that decimals (for 0 to 60 seconds) align vertically.

### Examples

#### Existing

```
  0.0s     debug: Example [ec=0xe60] [pid=80719]
               | doing something
 0.68s     debug: Example [ec=0xfb4] [pid=80719]
               | doing something
 0.86s     debug: Example [ec=0x1090] [pid=80719]
               | doing something
 2.68s     debug: Example [ec=0x10cc] [pid=80719]
               | doing something
  2.9s     debug: Example [ec=0x1108] [pid=80719]
               | doing something
12.43s     debug: Example [ec=0x111c] [pid=80719]
               | doing something
 29.8s     debug: Example [ec=0x1130] [pid=80719]
               | doing something
44.31s     debug: Example [ec=0x1144] [pid=80719]
               | doing something
```

#### Proposed

```
 0.00s     debug: Example [ec=0xe60] [pid=80719]
               | doing something
 0.68s     debug: Example [ec=0xfb4] [pid=80719]
               | doing something
 0.86s     debug: Example [ec=0x1090] [pid=80719]
               | doing something
 2.68s     debug: Example [ec=0x10cc] [pid=80719]
               | doing something
 2.90s     debug: Example [ec=0x1108] [pid=80719]
               | doing something
12.43s     debug: Example [ec=0x111c] [pid=80719]
               | doing something
29.80s     debug: Example [ec=0x1130] [pid=80719]
               | doing something
44.31s     debug: Example [ec=0x1144] [pid=80719]
               | doing something
```

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

### Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I updated tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).