### PR TITLE
Show compound units in elapsed time display.

### DIFF
--- a/lib/console/clock.rb
+++ b/lib/console/clock.rb
@@ -16,28 +16,28 @@ module Console
 				return format("%.2fs", duration)
 			end
 			
-			seconds = duration % 60
-			duration /= 60.0
+			minutes = duration / 60.0
 			
-			if duration < 60.0
-				return format("%dm%02ds", duration, seconds)
+			if minutes < 60.0
+				seconds = duration % 60
+				return format("%dm%02ds", minutes, seconds)
 			end
 			
-			minutes = duration % 60
-			duration /= 60.0
+			hours = minutes / 60.0
 			
-			if duration < 24.0
-				return format("%dh%02dm", duration, minutes)
+			if hours < 24.0
+				minutes = minutes % 60
+				return format("%dh%02dm", hours, minutes)
 			end
 			
-			hours = duration % 24
-			duration /= 24.0
+			days = hours / 24.0
 			
-			if duration < 100.0
-				return format("%dd%02dh", duration, hours)
+			if days < 100.0
+				hours = hours % 24
+				return format("%dd%02dh", days, hours)
 			end
 			
-			return format("%dd", duration)
+			return format("%dd", days)
 		end
 		
 		# @returns [Time] The current monotonic time.

--- a/lib/console/clock.rb
+++ b/lib/console/clock.rb
@@ -16,21 +16,28 @@ module Console
 				return format("%.2fs", duration)
 			end
 			
+			seconds = duration % 60
 			duration /= 60.0
 			
 			if duration < 60.0
-				return "#{duration.floor}m"
+				return format("%dm%02ds", duration, seconds)
 			end
 			
+			minutes = duration % 60
 			duration /= 60.0
 			
 			if duration < 24.0
-				return "#{duration.floor}h"
+				return format("%dh%02dm", duration, minutes)
 			end
 			
+			hours = duration % 24
 			duration /= 24.0
 			
-			return "#{duration.floor}d"
+			if duration < 100.0
+				return format("%dd%02dh", duration, hours)
+			end
+			
+			return format("%dd", duration)
 		end
 		
 		# @returns [Time] The current monotonic time.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Show compound units in elapsed time display.
+
 ## v1.36.0
 
   - Add a `size_limit` to `Console::Format::Safe` (default 16KiB) which rebuilds oversized records field-by-field, keeping as many top-level fields as fit within the limit.

--- a/test/console/clock.rb
+++ b/test/console/clock.rb
@@ -19,27 +19,32 @@ describe Console::Clock do
 		end
 		
 		it "can format minutes" do
-			expect(subject.formatted_duration(60)).to be == "1m"
-			expect(subject.formatted_duration(61)).to be == "1m"
-			expect(subject.formatted_duration(120)).to be == "2m"
-			expect(subject.formatted_duration(600)).to be == "10m"
-			expect(subject.formatted_duration(3599)).to be == "59m"
+			expect(subject.formatted_duration(60)).to be == "1m00s"
+			expect(subject.formatted_duration(61)).to be == "1m01s"
+			expect(subject.formatted_duration(120)).to be == "2m00s"
+			expect(subject.formatted_duration(600)).to be == "10m00s"
+			expect(subject.formatted_duration(3599)).to be == "59m59s"
 		end
 		
 		it "can format hours" do
-			expect(subject.formatted_duration(3600)).to be == "1h"
-			expect(subject.formatted_duration(3601)).to be == "1h"
-			expect(subject.formatted_duration(7200)).to be == "2h"
-			expect(subject.formatted_duration(36000)).to be == "10h"
-			expect(subject.formatted_duration(86399)).to be == "23h"
+			expect(subject.formatted_duration(3600)).to be == "1h00m"
+			expect(subject.formatted_duration(3601)).to be == "1h00m"
+			expect(subject.formatted_duration(7200)).to be == "2h00m"
+			expect(subject.formatted_duration(36000)).to be == "10h00m"
+			expect(subject.formatted_duration(86399)).to be == "23h59m"
 		end
 		
 		it "can format days" do
-			expect(subject.formatted_duration(86400)).to be == "1d"
-			expect(subject.formatted_duration(86401)).to be == "1d"
-			expect(subject.formatted_duration(172800)).to be == "2d"
-			expect(subject.formatted_duration(604799)).to be == "6d"
-			expect(subject.formatted_duration(864000)).to be == "10d"
+			expect(subject.formatted_duration(86400)).to be == "1d00h"
+			expect(subject.formatted_duration(86401)).to be == "1d00h"
+			expect(subject.formatted_duration(172800)).to be == "2d00h"
+			expect(subject.formatted_duration(604799)).to be == "6d23h"
+			expect(subject.formatted_duration(864000)).to be == "10d00h"
+		end
+		
+		it "can format many days" do
+			expect(subject.formatted_duration(8640000)).to be == "100d"
+			expect(subject.formatted_duration(86400000)).to be == "1000d"
 		end
 	end
 	

--- a/test/console/clock.rb
+++ b/test/console/clock.rb
@@ -16,6 +16,7 @@ describe Console::Clock do
 			expect(subject.formatted_duration(2)).to be == "2.00s"
 			expect(subject.formatted_duration(10)).to be == "10.00s"
 			expect(subject.formatted_duration(59)).to be == "59.00s"
+			expect(subject.formatted_duration(59.999)).to be == "60.00s"
 		end
 		
 		it "can format minutes" do

--- a/test/console/clock.rb
+++ b/test/console/clock.rb
@@ -21,8 +21,10 @@ describe Console::Clock do
 		it "can format minutes" do
 			expect(subject.formatted_duration(60)).to be == "1m00s"
 			expect(subject.formatted_duration(61)).to be == "1m01s"
+			expect(subject.formatted_duration(61.999)).to be == "1m01s"
 			expect(subject.formatted_duration(120)).to be == "2m00s"
 			expect(subject.formatted_duration(600)).to be == "10m00s"
+			expect(subject.formatted_duration(3599.999)).to be == "59m59s"
 			expect(subject.formatted_duration(3599)).to be == "59m59s"
 		end
 		
@@ -31,6 +33,7 @@ describe Console::Clock do
 			expect(subject.formatted_duration(3601)).to be == "1h00m"
 			expect(subject.formatted_duration(7200)).to be == "2h00m"
 			expect(subject.formatted_duration(36000)).to be == "10h00m"
+			expect(subject.formatted_duration(86399.999)).to be == "23h59m"
 			expect(subject.formatted_duration(86399)).to be == "23h59m"
 		end
 		
@@ -43,6 +46,7 @@ describe Console::Clock do
 		end
 		
 		it "can format many days" do
+			expect(subject.formatted_duration(8640000 - 1)).to be == "99d23h"
 			expect(subject.formatted_duration(8640000)).to be == "100d"
 			expect(subject.formatted_duration(86400000)).to be == "1000d"
 		end


### PR DESCRIPTION
When logging from a long-running script, I'll get many messages in a row that all show  `1h`. It would be nice to have a minute column, so I can see elapsed time between events at a glance.

So following up on #84, I suggest to show compound units in the elapsed time display. Instead of collapsing to a single coarse unit, each range past 60 seconds keeps sub-unit resolution and aligns vertically in a fixed-width format.

### Examples

#### Existing

```
 0.84s     debug: Example [ec=0xe60] [pid=80719]
59.99s     debug: Example [ec=0xfb4] [pid=80719]
    2m     debug: Example [ec=0x1090] [pid=80719]
   23m     debug: Example [ec=0x10cc] [pid=80719]
    1h     debug: Example [ec=0x1108] [pid=80719]
    9h     debug: Example [ec=0x111c] [pid=80719]
    2d     debug: Example [ec=0x1130] [pid=80719]
```

#### Proposed

```
 0.84s     debug: Example [ec=0xe60] [pid=80719]
59.99s     debug: Example [ec=0xfb4] [pid=80719]
 2m03s     debug: Example [ec=0x1090] [pid=80719]
23m47s     debug: Example [ec=0x10cc] [pid=80719]
 1h05m     debug: Example [ec=0x1108] [pid=80719]
 9h48m     debug: Example [ec=0x111c] [pid=80719]
 2d05h     debug: Example [ec=0x1130] [pid=80719]
```

The unit divider (`.`, `m`, `h`, `d`) stays in the third column, so the field still reads cleanly down the column. Past 99 days it falls back to bare days (`100d`, `1000d`) to stay within the six-column width.

`Clock.formatted_duration` also feeds the progress summary sentence, which now reads `completed in 2m05s, 1m02s remaining` instead of `2m, 1m`. (If this change is not desired, the implementations can be separated.)

### Types of Changes

- New feature.

### Contribution

- [x] I ~~added~~ updated tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).